### PR TITLE
feat: add create_launcher configuration option for venv setup

### DIFF
--- a/tests/test_create_venvs.py
+++ b/tests/test_create_venvs.py
@@ -7,7 +7,7 @@ from typer.testing import CliRunner
 
 from trobz_local.concurrency import TaskResult
 from trobz_local.main import _create_venvs, app
-from trobz_local.utils import get_config
+from trobz_local.utils import ConfigModel, get_config
 
 runner = CliRunner()
 task = TaskID(0)
@@ -62,6 +62,7 @@ def test_create_venv_success(tmp_path, mock_get_uv_path):
             "--preset",
             "local",
             "--verbose",
+            "--create-launcher",
         ]
         mock_subprocess_run.assert_called_once_with(
             expected_cmd,
@@ -96,6 +97,33 @@ def test_create_venv_failure(tmp_path, mock_get_uv_path):
         assert found_error_description
 
 
+def test_create_venv_without_launcher(tmp_path, mock_get_uv_path):
+    """When create_launcher=False, --create-launcher is not in the command."""
+    progress_mock = MagicMock(spec=Progress)
+    version = "16.0"
+    uv_path = "uv"
+    odoo_dir_base = tmp_path / "code" / "odoo" / "odoo"
+    venv_dir_base = tmp_path / "code" / "venvs"
+
+    with patch("subprocess.run") as mock_subprocess_run:
+        _create_venvs(progress_mock, task, version, uv_path, odoo_dir_base, venv_dir_base, create_launcher=False)
+
+        called_cmd = mock_subprocess_run.call_args[0][0]
+        assert "--create-launcher" not in called_cmd
+
+
+def test_config_model_create_launcher_default():
+    """ConfigModel defaults create_launcher to True when omitted."""
+    model = ConfigModel(versions=["18.0"])
+    assert model.create_launcher is True
+
+
+def test_config_model_create_launcher_false():
+    """ConfigModel accepts create_launcher = false."""
+    model = ConfigModel(versions=["18.0"], create_launcher=False)
+    assert model.create_launcher is False
+
+
 def test_create_venvs_calls_run_tasks_correctly(tmp_path, mock_config, mock_typer_confirm):
     mock_results = [
         TaskResult(success=True, name="venv-16.0", message="Completed"),
@@ -103,7 +131,10 @@ def test_create_venvs_calls_run_tasks_correctly(tmp_path, mock_config, mock_type
     ]
     with (
         patch("trobz_local.main.run_tasks", return_value=mock_results) as mock_run_tasks,
-        patch("trobz_local.utils.get_config", return_value={"versions": ["16.0", "17.0"], "repos": {}, "tools": {}}),
+        patch(
+            "trobz_local.utils.get_config",
+            return_value={"versions": ["16.0", "17.0"], "repos": {}, "tools": {}, "create_launcher": True},
+        ),
         patch("trobz_local.utils.get_uv_path", return_value="mock_uv_path"),
     ):
         result = runner.invoke(app, ["create-venvs"])

--- a/trobz_local/assets/odoo_dev.toml
+++ b/trobz_local/assets/odoo_dev.toml
@@ -1,4 +1,5 @@
 versions = ["14.0", "15.0", "16.0", "17.0", "18.0"]
+create_launcher = true
 
 [tools]
 uv = [

--- a/trobz_local/main.py
+++ b/trobz_local/main.py
@@ -400,6 +400,9 @@ def create_venvs(ctx: typer.Context):
 
     msg += "\nFor more information, read at https://github.com/trobz/odoo-venv."
 
+    if config.get("create_launcher", True):
+        msg += "\nLauncher scripts will be created in ~/.local/bin/ (e.g. odoo-v18).\n"
+
     confirm_step(
         ctx,
         msg,
@@ -408,6 +411,7 @@ def create_venvs(ctx: typer.Context):
 
     uv_path = get_uv_path()
     odoo_dir_base = code_root / "odoo" / "odoo"
+    create_launcher = config.get("create_launcher", True)
 
     concurrency_tasks = []
     for version in versions:
@@ -419,6 +423,7 @@ def create_venvs(ctx: typer.Context):
                 "uv_path": uv_path,
                 "odoo_dir_base": odoo_dir_base,
                 "venv_dir_base": venv_dir_base,
+                "create_launcher": create_launcher,
             },
         })
     results = run_tasks(concurrency_tasks)
@@ -434,7 +439,13 @@ def create_venvs(ctx: typer.Context):
 
 
 def _create_venvs(
-    progress: Progress, task_id: TaskID, version: str, uv_path: str, odoo_dir_base: Path, venv_dir_base: Path
+    progress: Progress,
+    task_id: TaskID,
+    version: str,
+    uv_path: str,
+    odoo_dir_base: Path,
+    venv_dir_base: Path,
+    create_launcher: bool = True,
 ):
     progress.update(task_id, description=f"Creating venv for {version}...", total=100, completed=0, start=True)
     odoo_dir = odoo_dir_base / version
@@ -456,6 +467,8 @@ def _create_venvs(
             "local",
             "--verbose",
         ]
+        if create_launcher:
+            cmd.append("--create-launcher")
 
         subprocess.run(  # noqa: S603
             cmd,

--- a/trobz_local/utils.py
+++ b/trobz_local/utils.py
@@ -134,6 +134,7 @@ class ToolsConfig(BaseModel):
 
 class ConfigModel(BaseModel):
     versions: list[str] = Field(default_factory=list)
+    create_launcher: bool = True
     tools: ToolsConfig = Field(default_factory=ToolsConfig)
     repos: RepoConfig = Field(default_factory=RepoConfig)
 


### PR DESCRIPTION
Add support for create_launcher flag in ConfigModel to enable automatic launcher script generation during virtual environment creation. This feature allows users to optionally generate executable launcher scripts when setting up development environments.

Changes:
- Add create_launcher bool field to ConfigModel in utils.py
- Wire create_launcher flag into create-venvs command in main.py
- Add create_launcher to example config in assets/odoo_dev.toml
- Add comprehensive tests for create_launcher feature in test_create_venvs.py